### PR TITLE
Apollo feedback

### DIFF
--- a/frontend/components/AddToCart.js
+++ b/frontend/components/AddToCart.js
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { Mutation, Query } from 'react-apollo';
+import { Mutation } from 'react-apollo';
 import PropTypes from 'prop-types';
 import {
   ADD_TO_CART_MUTATION,
@@ -34,21 +34,17 @@ class AddToCart extends Component {
   render() {
     const { id } = this.props;
     return (
-      <Query query={CURRENT_USER_QUERY}>
-        {() => (
-          <Mutation
-            mutation={ADD_TO_CART_MUTATION}
-            variables={{ id }}
-            update={this.update}
-          >
-            {(addToCart, { loading }) => (
-              <button disabled={loading} onClick={addToCart}>
-                🛒 Add{loading && 'ing'} To Cart
-              </button>
-            )}
-          </Mutation>
+      <Mutation
+        mutation={ADD_TO_CART_MUTATION}
+        variables={{ id }}
+        update={this.update}
+      >
+        {(addToCart, { loading }) => (
+          <button disabled={loading} onClick={addToCart}>
+            🛒 Add{loading && 'ing'} To Cart
+          </button>
         )}
-      </Query>
+      </Mutation>
     );
   }
 }

--- a/frontend/components/AddToCart.js
+++ b/frontend/components/AddToCart.js
@@ -1,18 +1,23 @@
 import { Component } from 'react';
 import { Mutation, Query } from 'react-apollo';
 import PropTypes from 'prop-types';
-import { ADD_TO_CART_MUTATION, CURRENT_USER_QUERY } from '../queries/queries.graphql';
+import {
+  ADD_TO_CART_MUTATION,
+  CURRENT_USER_QUERY,
+} from '../queries/queries.graphql';
 
 class AddToCart extends Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
   };
 
-  update = (proxy, payload) => {
+  update = (cache, payload) => {
     const newCartItem = payload.data.addToCart;
-    const data = proxy.readQuery({ query: CURRENT_USER_QUERY });
+    const data = cache.readQuery({ query: CURRENT_USER_QUERY });
 
-    const existingIndex = data.me.cart.findIndex(cartItem => cartItem.id === newCartItem.id);
+    const existingIndex = data.me.cart.findIndex(
+      cartItem => cartItem.id === newCartItem.id,
+    );
     if (existingIndex >= 0) {
       // already in cache, just replace it
       data.me.cart = [
@@ -23,7 +28,7 @@ class AddToCart extends Component {
     } else {
       data.me.cart = [...data.me.cart, newCartItem];
     }
-    proxy.writeQuery({ query: CURRENT_USER_QUERY, data });
+    cache.writeQuery({ query: CURRENT_USER_QUERY, data });
   };
 
   render() {
@@ -31,7 +36,11 @@ class AddToCart extends Component {
     return (
       <Query query={CURRENT_USER_QUERY}>
         {() => (
-          <Mutation mutation={ADD_TO_CART_MUTATION} variables={{ id }} update={this.update}>
+          <Mutation
+            mutation={ADD_TO_CART_MUTATION}
+            variables={{ id }}
+            update={this.update}
+          >
             {(addToCart, { loading }) => (
               <button disabled={loading} onClick={addToCart}>
                 🛒 Add{loading && 'ing'} To Cart

--- a/frontend/components/Cart.js
+++ b/frontend/components/Cart.js
@@ -17,19 +17,23 @@ import CloseButton from './styles/CloseButton';
 import SickButton from './styles/SickButton';
 
 const Composed = adopt({
-  toggleCart: <Mutation mutation={TOGGLE_CART_MUTATION}>{() => {}}</Mutation>,
-  localState: <Query query={LOCAL_STATE_QUERY}>{() => {}}</Query>,
-  currentUser: (
-    <Query query={CURRENT_USER_QUERY} data-test="cart">
-      {() => {}}
-    </Query>
+  toggleCart: ({ render }) => (
+    <Mutation mutation={TOGGLE_CART_MUTATION}>
+      {(mutate, result) => render({ mutate, result })}
+    </Mutation>
   ),
+  localState: <Query query={LOCAL_STATE_QUERY} />,
+  currentUser: <Query query={CURRENT_USER_QUERY} data-test="cart" />,
 });
 
 const Cart = () => (
   <Composed>
     {({ toggleCart, localState, currentUser }) => {
-      const { data: { me }, error, loading } = currentUser;
+      const {
+        data: { me },
+        error,
+        loading,
+      } = currentUser;
       if (loading) return <p>Loading...</p>;
       if (error) return <Error error={error} />;
       if (!me) return null;
@@ -42,11 +46,16 @@ const Cart = () => (
 
             <Supreme>{me.name}'s Cart.</Supreme>
             <p>
-              You have {me.cart.length} item{me.cart.length === 1 ? '' : 's'} in your cart.
+              You have {me.cart.length} item{me.cart.length === 1 ? '' : 's'} in
+              your cart.
             </p>
           </header>
 
-          <ul>{me.cart.map(cartItem => <CartItem key={cartItem.id} cartItem={cartItem} />)}</ul>
+          <ul>
+            {me.cart.map(cartItem => (
+              <CartItem key={cartItem.id} cartItem={cartItem} />
+            ))}
+          </ul>
           <footer>
             <p>{formatMoney(calcTotalPrice(me.cart))}</p>
             <TakeMyMoney>

--- a/frontend/components/DeleteItem.js
+++ b/frontend/components/DeleteItem.js
@@ -1,20 +1,23 @@
 import React from 'react';
 import { Mutation } from 'react-apollo';
 import PropTypes from 'prop-types';
-import { REMOVE_ITEM_MUTATION, ALL_ITEMS_QUERY } from '../queries/queries.graphql';
+import {
+  REMOVE_ITEM_MUTATION,
+  ALL_ITEMS_QUERY,
+} from '../queries/queries.graphql';
 
 class DeleteItem extends React.Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
   };
 
-  update = (proxy, payload) => {
+  update = (cache, payload) => {
     const deletedItem = payload.data.deleteItem;
-    const data = proxy.readQuery({ query: ALL_ITEMS_QUERY });
+    const data = cache.readQuery({ query: ALL_ITEMS_QUERY });
     // filter this one out
     data.items = data.items.filter(item => item.id !== deletedItem.id);
-    // write the data back to the proxy
-    proxy.writeQuery({ query: ALL_ITEMS_QUERY, data });
+    // write the data back to the cache
+    cache.writeQuery({ query: ALL_ITEMS_QUERY, data });
   };
 
   render() {

--- a/frontend/components/RemoveFromCart.js
+++ b/frontend/components/RemoveFromCart.js
@@ -2,7 +2,10 @@ import { Component } from 'react';
 import { Mutation } from 'react-apollo';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { REMOVE_FROM_CART_MUTATION, CURRENT_USER_QUERY } from '../queries/queries.graphql';
+import {
+  REMOVE_FROM_CART_MUTATION,
+  CURRENT_USER_QUERY,
+} from '../queries/queries.graphql';
 
 const BigButton = styled.button`
   font-size: 3rem;
@@ -19,12 +22,12 @@ class RemoveFromCart extends Component {
     id: PropTypes.string.isRequired,
   };
 
-  update = (proxy, payload) => {
-    const data = proxy.readQuery({ query: CURRENT_USER_QUERY });
+  update = (cache, payload) => {
+    const data = cache.readQuery({ query: CURRENT_USER_QUERY });
     // console.log(data.me.cart[0]);
     const cartItemId = payload.data.removeFromCart.id;
     data.me.cart = data.me.cart.filter(cartItem => cartItem.id !== cartItemId);
-    proxy.writeQuery({ query: CURRENT_USER_QUERY, data });
+    cache.writeQuery({ query: CURRENT_USER_QUERY, data });
   };
 
   render() {
@@ -35,7 +38,11 @@ class RemoveFromCart extends Component {
         update={this.update}
       >
         {(removeFromCart, { loading }) => (
-          <BigButton disabled={loading} title="Remove From Cart" onClick={removeFromCart}>
+          <BigButton
+            disabled={loading}
+            title="Remove From Cart"
+            onClick={removeFromCart}
+          >
             ×
           </BigButton>
         )}

--- a/frontend/lib/withData.js
+++ b/frontend/lib/withData.js
@@ -5,9 +5,11 @@ import { LOCAL_STATE_QUERY } from '../queries/queries.graphql';
 
 function createClient({ headers }) {
   return new ApolloClient({
-    uri: process.env.NODE_ENV === 'development' ? 'http://localhost:4444' : 'http://localhost:4444',
-    ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
-    request: async operation => {
+    uri:
+      process.env.NODE_ENV === 'development'
+        ? 'http://localhost:4444'
+        : 'http://localhost:4444',
+    request: operation => {
       operation.setContext({
         fetchOptions: {
           credentials: 'include',
@@ -19,7 +21,7 @@ function createClient({ headers }) {
       resolvers: {
         Mutation: {
           toggleCart(_, variables, { cache }) {
-            const { cartOpen } = cache.read({ query: LOCAL_STATE_QUERY });
+            const { cartOpen } = cache.readQuery({ query: LOCAL_STATE_QUERY });
             const data = { data: { cartOpen: !cartOpen } };
             cache.writeData(data);
             return data;


### PR DESCRIPTION
This is looking **awesome**! I love how practical the examples are. Thank you so much for putting it together, I think it's going to help a lot of people learn GraphQL and Apollo! 🎉 

Just a couple changes I made:
- Removed `ssrMode` from Apollo Client creation. `apollo-boost` doesn't support this option, so it was never passed through
- Changed `cache.read` to `cache.readQuery` since we recommend that people don't invoke cache methods directly
- Renamed proxy in `update` methods to `cache` - this is what we recommend in the docs since proxy seems scary
- Removed an unused `Query` component
- Refactored `react-adopt` portion to match the recommended usage that the maintainer sent me: https://gist.github.com/pedronauck/394dc2a797b000ae80693d94c832d79d

Before you start recording, we should refactor the queries out of the `queries.graphql` file and colocate them with their respective components using the `gql` function. Would you like me to do this refactor?

Also, I was curious why you were using a direct write and a client-side resolver two separate times to toggle the cart with `apollo-link-state`. Is this to compare the approaches?