### PR TITLE
Custom titlebar for Windows and Linux users

### DIFF
--- a/sick-fits/backend/.vscode/settings.json
+++ b/sick-fits/backend/.vscode/settings.json
@@ -5,7 +5,7 @@
     "titleBar.activeBackground": "#FF2C70",
     "titleBar.inactiveBackground": "#FF2C70CC"
   }
-}
+
 
 
 

--- a/sick-fits/backend/.vscode/settings.json
+++ b/sick-fits/backend/.vscode/settings.json
@@ -1,23 +1,11 @@
-// Mac users
+// Windows and Linux users enable custom titlebar 
+//"window.titleBarStyle": "custom"
 {
   "workbench.colorCustomizations": {
     "titleBar.activeBackground": "#FF2C70",
     "titleBar.inactiveBackground": "#FF2C70CC"
   }
 }
-
-
-// Windows and Linux users
-/* {
-  "window.titleBarStyle": "custom",
-  "workbench.colorCustomizations": {
-    // Name of the theme you are using "[Cobalt2]"
-    "[Cobalt2]": {
-      "titleBar.activeBackground": "#FF2C70",
-      "titleBar.inactiveBackground": "#FF2C70CC"
-    },
-  },
-} */
 
 
 

--- a/sick-fits/backend/.vscode/settings.json
+++ b/sick-fits/backend/.vscode/settings.json
@@ -1,5 +1,23 @@
+// Mac users
 {
   "workbench.colorCustomizations": {
     "titleBar.activeBackground": "#FF2C70",
     "titleBar.inactiveBackground": "#FF2C70CC"
   }
+}
+
+
+// Windows and linux users
+/* {
+  "window.titleBarStyle": "custom",
+  "workbench.colorCustomizations": {
+    // Name of the theme you are using "[Cobalt2]"
+    "[Cobalt2]": {
+      "titleBar.activeBackground": "#FF2C70",
+      "titleBar.inactiveBackground": "#FF2C70CC"
+    },
+  },
+} */
+
+
+

--- a/sick-fits/backend/.vscode/settings.json
+++ b/sick-fits/backend/.vscode/settings.json
@@ -5,7 +5,7 @@
     "titleBar.activeBackground": "#FF2C70",
     "titleBar.inactiveBackground": "#FF2C70CC"
   }
-
+}
 
 
 

--- a/sick-fits/backend/.vscode/settings.json
+++ b/sick-fits/backend/.vscode/settings.json
@@ -7,7 +7,7 @@
 }
 
 
-// Windows and linux users
+// Windows and Linux users
 /* {
   "window.titleBarStyle": "custom",
   "workbench.colorCustomizations": {

--- a/sick-fits/frontend/.vscode/settings.json
+++ b/sick-fits/frontend/.vscode/settings.json
@@ -7,3 +7,4 @@
     "titleBar.activeBackground": "#FFC600",
     "titleBar.inactiveBackground": "#FFC600CC"
   }
+}

--- a/sick-fits/frontend/.vscode/settings.json
+++ b/sick-fits/frontend/.vscode/settings.json
@@ -1,3 +1,5 @@
+// Windows and Linux users enable custom titlebar 
+//"window.titleBarStyle": "custom"
 {
   "workbench.colorCustomizations": {
     "titleBar.activeForeground": "#000",


### PR DESCRIPTION
Custom titlebar info for Windows and Linux users make sure that you enable the custom titlebar in user settings by `"window.titleBarStyle": "custom"` 
