### PR TITLE
Force Custom Font

### DIFF
--- a/finished-application/frontend/components/styles/ItemStyles.js
+++ b/finished-application/frontend/components/styles/ItemStyles.js
@@ -30,6 +30,7 @@ const Item = styled.div`
     & > * {
       background: white;
       border: 0;
+      font-family: 'radnika_next';
       font-size: 1rem;
       padding: 1rem;
     }


### PR DESCRIPTION
The browser's user agent styles forces the buttons to use system-ui font instead of 'radnika_next'.
Resulting in the buttons and the sibling a tag to be mismatched fonts.