### PR TITLE
Pointing prisma.yml to correct path

### DIFF
--- a/sick-fits/backend/.graphqlconfig.yml
+++ b/sick-fits/backend/.graphqlconfig.yml
@@ -7,4 +7,4 @@ projects:
   prisma:
     schemaPath: "src/generated/prisma.graphql"
     extensions:
-      prisma: prisma/prisma.yml
+      prisma: prisma.yml


### PR DESCRIPTION
Since prisma.yml gets created on the /backend root directory.
Tested with graphql-cli and displayed eror — "prisma/prisma.yml could not be found."
Prisma post-deploy command did not show an error.