### PR TITLE
Update jest dep version to update jsdom dep version with recent bug fix

### DIFF
--- a/sick-fits/frontend/package.json
+++ b/sick-fits/frontend/package.json
@@ -42,7 +42,7 @@
     "casual": "^1.5.19",
     "enzyme-to-json": "^3.3.4",
     "graphql-tools": "^3.0.2",
-    "jest": "^22.4.4",
+    "jest": "^23.6.0",
     "jest-transform-graphql": "^2.1.0"
   },
   "jest": {


### PR DESCRIPTION
For Vid #55 [Unit Testing]

Starter file package.json seems to have jest v22.4.4, which installs jsdom v11.12 causing 'localStorage is not available for opaque origins' error when 'npm run test' is executed.

It seems like the package.json file in finished-application directory has a corrected version of jest (^23.6.0). Hoping this update on the starter file can help others go through the tutorials without an error.