### PR TITLE
Video 29 Scalar Type of resetTokenExpiry

### DIFF
--- a/finished-application/backend/datamodel.graphql
+++ b/finished-application/backend/datamodel.graphql
@@ -13,7 +13,7 @@ type User {
   email: String! @unique
   password: String!
   resetToken: String
-  resetTokenExpiry: String
+  resetTokenExpiry: Float
   permissions: [Permission]
   cart: [CartItem!]!
 }


### PR DESCRIPTION
Setting up the requestReset Mutation to create the resetTokenExpiry I receive the error, `Expected type String at value.resetTokenExpiry; String cannot represent a non string value`
resetTokenExpiry is the number of milliseconds until the expiry, if .toString() is applied to that number there is no issue in this resolver until the value is later used in the resetPassword resolver. With that error being, ` Got invalid value. Expected type String at value.resetTokenExpiry_gte; String cannot represent a non string value`

Therefore switching the scalar type of resetTokenExpiry to a Float appeases these errors, requires no additional changes to the codebase and reflects the value type. 
Curious, if differing versions of Prisma on Prisma Cloud(1.18.beta-1) is the reason for this error reporting.