### PR TITLE
Add updateItem permission checking starting on step 37

### DIFF
--- a/finished-application/backend/src/resolvers/Mutation.js
+++ b/finished-application/backend/src/resolvers/Mutation.js
@@ -32,6 +32,20 @@ const Mutations = {
     return item;
   },
   updateItem(parent, args, ctx, info) {
+    // make sure user has permission to update
+    // 1. find the item
+    const where = { id: args.id }
+    // 2. check if they own it or have permissions
+    const item = await ctx.db.query.item({ where }, `{ id title user { id }}`);
+    const ownsItem = item.user.id === ctx.request.userId;
+    const hasPermissions = ctx.request.user.permissions.some(permission =>
+      ['ADMIN', 'ITEMUPDATE', 'PERMISSIONUPDATE'].includes(permission)
+    );
+
+    if (!ownsItem && !hasPermissions) {
+      throw new Error("You don't have permission to do that!");
+    }
+
     // first take a copy of the updates
     const updates = { ...args };
     // remove the ID from the updates

--- a/stepped-solutions/38/backend/src/resolvers/Mutation.js
+++ b/stepped-solutions/38/backend/src/resolvers/Mutation.js
@@ -31,6 +31,20 @@ const Mutations = {
     return item;
   },
   updateItem(parent, args, ctx, info) {
+    // make sure user has permission to update
+    // 1. find the item
+    const where = { id: args.id }
+    // 2. check if they own it or have permissions
+    const item = await ctx.db.query.item({ where }, `{ id title user { id }}`);
+    const ownsItem = item.user.id === ctx.request.userId;
+    const hasPermissions = ctx.request.user.permissions.some(permission =>
+      ['ADMIN', 'ITEMUPDATE', 'PERMISSIONUPDATE'].includes(permission)
+    );
+
+    if (!ownsItem && !hasPermissions) {
+      throw new Error("You don't have permission to do that!");
+    }
+
     // first take a copy of the updates
     const updates = { ...args };
     // remove the ID from the updates

--- a/stepped-solutions/41/backend/src/resolvers/Mutation.js
+++ b/stepped-solutions/41/backend/src/resolvers/Mutation.js
@@ -31,6 +31,20 @@ const Mutations = {
     return item;
   },
   updateItem(parent, args, ctx, info) {
+    // make sure user has permission to update
+    // 1. find the item
+    const where = { id: args.id }
+    // 2. check if they own it or have permissions
+    const item = await ctx.db.query.item({ where }, `{ id title user { id }}`);
+    const ownsItem = item.user.id === ctx.request.userId;
+    const hasPermissions = ctx.request.user.permissions.some(permission =>
+      ['ADMIN', 'ITEMUPDATE', 'PERMISSIONUPDATE'].includes(permission)
+    );
+
+    if (!ownsItem && !hasPermissions) {
+      throw new Error("You don't have permission to do that!");
+    }
+
     // first take a copy of the updates
     const updates = { ...args };
     // remove the ID from the updates

--- a/stepped-solutions/43/backend/src/resolvers/Mutation.js
+++ b/stepped-solutions/43/backend/src/resolvers/Mutation.js
@@ -31,6 +31,20 @@ const Mutations = {
     return item;
   },
   updateItem(parent, args, ctx, info) {
+    // make sure user has permission to update
+    // 1. find the item
+    const where = { id: args.id }
+    // 2. check if they own it or have permissions
+    const item = await ctx.db.query.item({ where }, `{ id title user { id }}`);
+    const ownsItem = item.user.id === ctx.request.userId;
+    const hasPermissions = ctx.request.user.permissions.some(permission =>
+      ['ADMIN', 'ITEMUPDATE', 'PERMISSIONUPDATE'].includes(permission)
+    );
+
+    if (!ownsItem && !hasPermissions) {
+      throw new Error("You don't have permission to do that!");
+    }
+
     // first take a copy of the updates
     const updates = { ...args };
     // remove the ID from the updates

--- a/stepped-solutions/51/backend/src/resolvers/Mutation.js
+++ b/stepped-solutions/51/backend/src/resolvers/Mutation.js
@@ -32,6 +32,20 @@ const Mutations = {
     return item;
   },
   updateItem(parent, args, ctx, info) {
+    // make sure user has permission to update
+    // 1. find the item
+    const where = { id: args.id }
+    // 2. check if they own it or have permissions
+    const item = await ctx.db.query.item({ where }, `{ id title user { id }}`);
+    const ownsItem = item.user.id === ctx.request.userId;
+    const hasPermissions = ctx.request.user.permissions.some(permission =>
+      ['ADMIN', 'ITEMUPDATE', 'PERMISSIONUPDATE'].includes(permission)
+    );
+
+    if (!ownsItem && !hasPermissions) {
+      throw new Error("You don't have permission to do that!");
+    }
+
     // first take a copy of the updates
     const updates = { ...args };
     // remove the ID from the updates

--- a/stepped-solutions/52/backend/src/resolvers/Mutation.js
+++ b/stepped-solutions/52/backend/src/resolvers/Mutation.js
@@ -32,6 +32,20 @@ const Mutations = {
     return item;
   },
   updateItem(parent, args, ctx, info) {
+    // make sure user has permission to update
+    // 1. find the item
+    const where = { id: args.id }
+    // 2. check if they own it or have permissions
+    const item = await ctx.db.query.item({ where }, `{ id title user { id }}`);
+    const ownsItem = item.user.id === ctx.request.userId;
+    const hasPermissions = ctx.request.user.permissions.some(permission =>
+      ['ADMIN', 'ITEMUPDATE', 'PERMISSIONUPDATE'].includes(permission)
+    );
+
+    if (!ownsItem && !hasPermissions) {
+      throw new Error("You don't have permission to do that!");
+    }
+
     // first take a copy of the updates
     const updates = { ...args };
     // remove the ID from the updates


### PR DESCRIPTION
After finishing the course and messing around with it, I realized there's no server-side validation for updating an item. You should be able to use most of the `deleteItem` validation, and it would also let you show examples of using the other permission types.

I think you'd most likely want to append this to video #37 (Locking Down DeleteItem Permissions).