### PR TITLE
Video #61 Testing Pagination - remove dead code

### DIFF
--- a/finished-application/frontend/__tests__/Pagination.test.js
+++ b/finished-application/frontend/__tests__/Pagination.test.js
@@ -36,7 +36,6 @@ describe('<Pagination/>', () => {
         <Pagination page={1} />
       </MockedProvider>
     );
-    const pagination = wrapper.find('[data-test="pagination"]');
     expect(wrapper.text()).toContain('Loading...');
   });
 


### PR DESCRIPTION
Video #61 @5:10 - 6:48 You write code that fails to find the expected result and so becomes "dead code". You say "let's save that for the next one", but this code is only copied, never actually removed.

This PR removes that code.