### PR TITLE
Added Windows test script compatibility

### DIFF
--- a/sick-fits/frontend/package.json
+++ b/sick-fits/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "test": "NODE_ENV=test jest --watch",
+    "test-win": "SET NODE_ENV=test&& jest --watch",
     "heroku-postbuild": "next build"
   },
   "author": "",
@@ -54,7 +55,8 @@
     ],
     "transform": {
       "\\.(gql|graphql)$": "jest-transform-graphql",
-      ".*": "babel-jest"
+      ".*": "babel-jest",
+      "^.+\\.js?$": "babel-jest"
     }
   },
   "//": "This is our babel config, I prefer this over a .babelrc file",


### PR DESCRIPTION
Couple changes to have Jest and Enzyme to properly run tests in windows.
First, the run script `"test-win": "SET NODE_ENV=test&& jest --watch",`

SET is required for Windows to accept the NODE_ENV command and the "&&" operator, without spaces after "test" to correctly set the env.

Not sure why but I had to add ` "^.+\\.js?$": "babel-jest"` to the jest transform config or babel would not work with the import statements during the test routine. 