### PR TITLE
fix(router): update next router api

### DIFF
--- a/stepped-solutions/09/frontend/components/Header.js
+++ b/stepped-solutions/09/frontend/components/Header.js
@@ -4,17 +4,17 @@ import Router from 'next/router';
 import NProgress from 'nprogress';
 import Nav from './Nav';
 
-Router.onRouteChangeStart = () => {
+const handleRouteChangeStart = () => {
   NProgress.start();
-};
+}
 
-Router.onRouteChangeComplete = () => {
+const handleRouteChangeCompleteAndError = () => {
   NProgress.done();
-};
+}
 
-Router.onRouteChangeError = () => {
-  NProgress.done();
-};
+Router.events.on('routeChangeStart', handleRouteChangeStart);
+Router.events.on('routeChangeComplete', handleRouteChangeCompleteAndError);
+Router.events.on('routeChangeError', handleRouteChangeCompleteAndError);
 
 const Logo = styled.h1`
   font-size: 4rem;


### PR DESCRIPTION
Hey @wesbos! First, Thanks for your awesome courses, I'm enjoying learning everything new thing.

I found some issue in **Module #2 Visualizing Route Changes**. In this course, we use next.js `7.0`, when I checkout next.js router docs, I found router API already changed, but in course we still use legacy API and it work 😂, so I update part of this with latest router API.

Reference:

- https://github.com/zeit/next.js/pull/4726/files
- https://github.com/zeit/next.js/tree/7.0.0#router-events