### PR TITLE
Remove resetTokenExpiry offset

### DIFF
--- a/finished-application/backend/src/resolvers/Mutation.js
+++ b/finished-application/backend/src/resolvers/Mutation.js
@@ -153,7 +153,7 @@ const Mutations = {
     const [user] = await ctx.db.query.users({
       where: {
         resetToken: args.resetToken,
-        resetTokenExpiry_gte: Date.now() - 3600000,
+        resetTokenExpiry_gte: Date.now(),
       },
     });
     if (!user) {


### PR DESCRIPTION
I think this offset in the resetPassword query would allow the an expiry time of 2 hours. It's been removed.