### PR TITLE
updating font family styling for button in navigation menu

### DIFF
--- a/finished-application/frontend/components/styles/NavStyles.js
+++ b/finished-application/frontend/components/styles/NavStyles.js
@@ -20,6 +20,7 @@ const NavStyles = styled.ul`
     cursor: pointer;
     color: ${props => props.theme.black};
     font-weight: 800;
+    font-family: inherit;
     @media (max-width: 700px) {
       font-size: 10px;
       padding: 0 10px;

--- a/stepped-solutions/29/frontend/components/styles/NavStyles.js
+++ b/stepped-solutions/29/frontend/components/styles/NavStyles.js
@@ -20,6 +20,7 @@ const NavStyles = styled.ul`
     cursor: pointer;
     color: ${props => props.theme.black};
     font-weight: 800;
+    font-family: inherit;
     @media (max-width: 700px) {
       font-size: 10px;
       padding: 0 10px;


### PR DESCRIPTION
Since form elements don't inherit styles from the body, I added a `font-family` property to the CSS for the navigation menu anchors and buttons so they have consistent styling.

This was mentioned first in the video when creating the sign out button, so I added it to that video's stepped solution and the final solution.