### PR TITLE
Fixed: Red :after element not shown on small screens.

### DIFF
--- a/sick-fits/frontend/components/styles/NavStyles.js
+++ b/sick-fits/frontend/components/styles/NavStyles.js
@@ -51,6 +51,9 @@ const NavStyles = styled.ul`
       &:after {
         width: calc(100% - 60px);
       }
+    @media (max-width: 700px) {
+        width: calc(100% - 10px);
+    }
     }
   }
   @media (max-width: 1300px) {


### PR DESCRIPTION
While trying to follow the video,  edit, and see the output I ended up with a screen that was too small to display the red :after element and thought I had made a mistake.

![after-element-missing](https://user-images.githubusercontent.com/22648375/48661449-79101c80-ea37-11e8-850a-de25884235e9.gif)
