### PR TITLE
Update component name from Sell to ResetPage

### DIFF
--- a/finished-application/frontend/pages/reset.js
+++ b/finished-application/frontend/pages/reset.js
@@ -1,10 +1,10 @@
 import Reset from '../components/Reset';
 
-const Sell = props => (
+const ResetPage = props => (
   <div>
     <p>Reset Your Password {props.query.resetToken}</p>
     <Reset resetToken={props.query.resetToken} />
   </div>
 );
 
-export default Sell;
+export default ResetPage;


### PR DESCRIPTION
The component exported by `pages/reset.js` was named `Sell` because it was copy-pasted from another file. This PR updates that component name from `Sell` to `ResetPage`.