### PR TITLE
Add awareOfUnicodeTokens: true to fix failing test

### DIFF
--- a/finished-application/frontend/components/Order.js
+++ b/finished-application/frontend/components/Order.js
@@ -56,7 +56,7 @@ class Order extends React.Component {
               </p>
               <p>
                 <span>Date</span>
-                <span>{format(order.createdAt, 'MMMM d, YYYY h:mm a')}</span>
+                <span>{format(order.createdAt, 'MMMM d, YYYY h:mm a', { awareOfUnicodeTokens: true })}</span>
               </p>
               <p>
                 <span>Order Total</span>


### PR DESCRIPTION
Steps to reproduce failing test:
1. clone repo
2. `cd finished-application/frontend`
3. `yarn`
4. `npm test`
5. Confirm you see the following error: 
```
Error: Uncaught [RangeError: `options.awareOfUnicodeTokens` must be set to `true` to use `YYYY` token; see: https://git.io/fxCyr]
```

Solution:
`- <span>{format(order.createdAt, 'MMMM d, YYYY h:mm a')}</span>`
`+ <span>{format(order.createdAt, 'MMMM d, YYYY h:mm a', { awareOfUnicodeTokens: true })}</span>`