### PR TITLE
Fix view permission checking in order query

### DIFF
--- a/finished-application/backend/src/resolvers/Query.js
+++ b/finished-application/backend/src/resolvers/Query.js
@@ -44,7 +44,7 @@ const Query = {
     // 3. Check if the have the permissions to see this order
     const ownsOrder = order.user.id === ctx.request.userId;
     const hasPermissionToSeeOrder = ctx.request.user.permissions.includes('ADMIN');
-    if (!ownsOrder || !hasPermission) {
+    if (!ownsOrder && !hasPermissionToSeeOrder) {
       throw new Error('You cant see this buddd');
     }
     // 4. Return the order

--- a/stepped-solutions/53/backend/src/resolvers/Query.js
+++ b/stepped-solutions/53/backend/src/resolvers/Query.js
@@ -44,7 +44,7 @@ const Query = {
     // 3. Check if the have the permissions to see this order
     const ownsOrder = order.user.id === ctx.request.userId;
     const hasPermissionToSeeOrder = ctx.request.user.permissions.includes('ADMIN');
-    if (!ownsOrder || !hasPermission) {
+    if (!ownsOrder && !hasPermissionToSeeOrder) {
       throw new Error('You cant see this buddd');
     }
     // 4. Return the order

--- a/stepped-solutions/54/backend/src/resolvers/Query.js
+++ b/stepped-solutions/54/backend/src/resolvers/Query.js
@@ -44,7 +44,7 @@ const Query = {
     // 3. Check if the have the permissions to see this order
     const ownsOrder = order.user.id === ctx.request.userId;
     const hasPermissionToSeeOrder = ctx.request.user.permissions.includes('ADMIN');
-    if (!ownsOrder || !hasPermission) {
+    if (!ownsOrder && !hasPermissionToSeeOrder) {
       throw new Error('You cant see this buddd');
     }
     // 4. Return the order


### PR DESCRIPTION
I think this part of logic is wrong.
There are 2 mistakes here:

1. You mistyped `hasPermission` for `hasPermissionToSeeOrder`.
Since `hasPermission` is a function, it is always truthy.
2. The fact that it's always truthy also covers the bug in the logical operand.
The user should be banned only if he/she doesn't own the order **AND** doesn't have the `ADMIN` permission.
If we use **OR** operator here, then the owner which is not `ADMIN` will be banned from viewing his/her own order.