### PR TITLE
Update formatMoney test assertion with correct fractional amount

### DIFF
--- a/finished-application/frontend/__tests__/formatMoney.test.js
+++ b/finished-application/frontend/__tests__/formatMoney.test.js
@@ -18,6 +18,6 @@ describe('formatMoney Function', () => {
     expect(formatMoney(5012)).toEqual('$50.12');
     expect(formatMoney(101)).toEqual('$1.01');
     expect(formatMoney(110)).toEqual('$1.10');
-    expect(formatMoney(20893749823749823749)).toEqual('$208,937,498,237,498,240.00');
+    expect(formatMoney(20893749823749823749)).toEqual('$208,937,498,237,498,237.49');
   });
 });


### PR DESCRIPTION
Guessing there is a problem with the format money function for very large numbers