### PR TITLE
Update User.js

### DIFF
--- a/stepped-solutions/27/frontend/components/User.js
+++ b/stepped-solutions/27/frontend/components/User.js
@@ -19,7 +19,7 @@ const User = props => (
   </Query>
 );
 
-User.PropTypes = {
+User.propTypes = {
   children: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
Error: `Warning: Component User declared `PropTypes` instead of `propTypes`. Did you misspell the property assignment?`
Change: `User.PropTypes = {...}` to `User.propTypes = {...}`