### PR TITLE
Update Signup.test.js

### DIFF
--- a/stepped-solutions/64/frontend/__tests__/Signup.test.js
+++ b/stepped-solutions/64/frontend/__tests__/Signup.test.js
@@ -18,7 +18,7 @@ const mocks = [
   // signup mock mutation
   {
     request: {
-      query: SIGNUP_MUTATION,
+      mutation: SIGNUP_MUTATION,
       variables: {
         name: me.name,
         email: me.email,


### PR DESCRIPTION
was causing this issue 
```
<Signup/> › calls the mutation properly
No more mocked responses for the query: mutation SIGNUP_MUTATION($email: String!, $name: String!, $password: String!) { ... 
```