### PR TITLE
if error, don't break Pagination

### DIFF
--- a/finished-application/frontend/components/Pagination.js
+++ b/finished-application/frontend/components/Pagination.js
@@ -5,6 +5,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import PaginationStyles from './styles/PaginationStyles';
 import { perPage } from '../config';
+import Error from './ErrorMessage';
 
 const PAGINATION_QUERY = gql`
   query PAGINATION_QUERY {
@@ -20,7 +21,8 @@ const Pagination = props => (
   <Query query={PAGINATION_QUERY}>
     {({ data, loading, error }) => {
       if (loading) return <p>Loading...</p>;
-      const count = data.itemsConnection.aggregate.count;
+      if (error) return <Error error={error} />;
+      const count = data.itemsConnection.aggregate.count
       const pages = Math.ceil(count / perPage);
       const page = props.page;
       return (


### PR DESCRIPTION
If there is an error e.g a network error we should return your Error component as to not break the rest of the component e.g `const count = data.itemsConnection.aggregate.count`

OR
`const count = !error ? data.itemsConnection.aggregate.count : props`