### PR TITLE
Fix propTypes error

### DIFF
--- a/stepped-solutions/27/frontend/components/User.js
+++ b/stepped-solutions/27/frontend/components/User.js
@@ -19,7 +19,7 @@ const User = props => (
   </Query>
 );
 
-User.PropTypes = {
+User.propTypes = {
   children: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
using this solution, we get this error in the console:

``` Component User declared `PropTypes` instead of `propTypes`. Did you misspell the property assignment? ```

to fix it we need to change line 22 from PropTypes to propTypes