### PR TITLE
Fix error: Cannot query field "password" on type "User".

### DIFF
--- a/stepped-solutions/30/src/schema.graphql
+++ b/stepped-solutions/30/src/schema.graphql
@@ -25,6 +25,7 @@ type Query {
 type User{
   id: ID!
   name: String!
+  password: String!
   email: String!
   permissions: [Permission!]!
 }


### PR DESCRIPTION
In video 29 at around 1 min 15 secs, you delete the password field however this causes the reset password, signup and signin fields on /signup to throw an error of ```Shoot!Cannot query field "password" on type "User".``` in video 31

This is because in Mutation.js we have 

```
const updatedUser = await ctx.db.mutation.updateUser({
      where: { email: user.email },
      data: {
        password,
        resetToken: null,
        resetTokenExpiry: null,
      },
    });

```

so we actually need that password field otherwise it won't work

the ```# import * from './generated/prisma.graphql'``` doesn't seem to import the field of password on type User