### PR TITLE
updates NavStyles.js to fix typo in media query

### DIFF
--- a/finished-application/frontend/components/styles/NavStyles.js
+++ b/finished-application/frontend/components/styles/NavStyles.js
@@ -22,7 +22,7 @@ const NavStyles = styled.ul`
     font-weight: 800;
     @media (max-width: 700px) {
       font-size: 10px;
-      padding: 0 10px;
+      padding: 1rem;
     }
     &:before {
       content: '';
@@ -52,6 +52,9 @@ const NavStyles = styled.ul`
       outline: none;
       &:after {
         width: calc(100% - 60px);
+        @media (max-width: 700px) {
+          width: calc(100% - 10px);
+        }
       }
     }
   }

--- a/sick-fits/frontend/components/styles/NavStyles.js
+++ b/sick-fits/frontend/components/styles/NavStyles.js
@@ -20,7 +20,7 @@ const NavStyles = styled.ul`
     cursor: pointer;
     @media (max-width: 700px) {
       font-size: 10px;
-      padding: 0 10px;
+      padding: 1rem;
     }
     &:before {
       content: '';
@@ -50,10 +50,10 @@ const NavStyles = styled.ul`
       outline: none;
       &:after {
         width: calc(100% - 60px);
+        @media (max-width: 700px) {
+          width: calc(100% - 10px);
+        }
       }
-    @media (max-width: 700px) {
-        width: calc(100% - 10px);
-    }
     }
   }
   @media (max-width: 1300px) {


### PR DESCRIPTION
There was a typo in what I would assume would be the MQ for `&:after` pseudo  element. It ended up adding an incorrect width to the hovered element. This PR addresses that, and then makes a minor adjustment to stave off some of the funkiness of the hovered bar appearing below the nav bar bottom border.

In addition to fixing that within the `sick-fits/`, I added that to the `finished-application/` as well so the two would match in this case.