### PR TITLE
Update datamodel to match recent prisma changes

### DIFF
--- a/finished-application/backend/datamodel.graphql
+++ b/finished-application/backend/datamodel.graphql
@@ -14,8 +14,8 @@ type User {
   password: String!
   resetToken: String
   resetTokenExpiry: Float
-  permissions: [Permission]
-  cart: [CartItem!]!
+  permissions: [Permission] @scalarList(strategy: RELATION)
+  cart: [CartItem!]! @scalarList(strategy: RELATION)
 }
 
 type Item {


### PR DESCRIPTION
Based on recent Prisma changes. The code now gives an error on deploy like:
`
User
    ✖ Valid values for the strategy argument of `@scalarList` are: RELATION.
`
Answer on this issue: https://github.com/prisma/prisma/issues/4426