### PR TITLE
Updating styled-components to fix lesson 8

### DIFF
--- a/sick-fits/frontend/package.json
+++ b/sick-fits/frontend/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^16.5.2",
     "react-stripe-checkout": "^2.6.3",
     "react-transition-group": "^2.5.0",
-    "styled-components": "^3.4.9",
+    "styled-components": "^4.4.0",
     "waait": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating styled-components to version 4 to fix errors in Lesson 8

In Lesson 8 when we do

```js
Router.onRouteChangeError = () => {
  NProgress.done();
};
```
The application breaks, so we have to update styled-components because they stopped using React life-cycle methods in v4 and the app can compile again without any errors or warnings!