### PR TITLE
 Fix stepped-solution #15 GraphQL Item model fields

### DIFF
--- a/stepped-solutions/15/datamodel.graphql
+++ b/stepped-solutions/15/datamodel.graphql
@@ -11,7 +11,7 @@ type Item {
   image: String
   largeImage: String
   price: Int!
-  # createAt: DateTime!
-  # updatedAt: DateTime!
+  createdAt: DateTime! @createdAt
+  updatedAt: DateTime! @updatedAt
   # user: User!
 }


### PR DESCRIPTION
The code found in the stepped-solution #15 files still contain the error made in misspelling the "createdAt" field for the Item model.

Furthermore, Prisma has created the `@createdAt` and `@modifiedAt` directives that need to be assigned to the corresponding fields in the Item model