### PR TITLE
refactor: remove extra font-size

### DIFF
--- a/sick-fits/frontend/components/styles/ItemStyles.js
+++ b/sick-fits/frontend/components/styles/ItemStyles.js
@@ -13,7 +13,6 @@ const Item = styled.div`
     object-fit: cover;
   }
   p {
-    font-size: 12px;
     line-height: 2;
     font-weight: 300;
     flex-grow: 1;


### PR DESCRIPTION
`font-size` is set twice in the same selector, I'm willing to bet this is not some sort of fallback?