### PR TITLE
Fix Apollo endpoint URL

### DIFF
--- a/sick-fits/frontend/config.js
+++ b/sick-fits/frontend/config.js
@@ -1,4 +1,4 @@
 // This is client side config only - don't put anything in here that shouldn't be public!
-export const endpoint = `http://localhost:3000/admin/api`;
+export const endpoint = `http://localhost:3000/api/graphql`;
 export const prodEndpoint = `fill me is when we deploy`;
 export const perPage = 4;


### PR DESCRIPTION
The URL is correct in the `finished-application` - but it's using an incorrect URL in the `starter-files` 🙂 
https://github.com/wesbos/Advanced-React/blob/master/finished-application/frontend/config.js#L2