### PR TITLE
Fix global CSS lightGray

### DIFF
--- a/finished-application/frontend/components/Page.js
+++ b/finished-application/frontend/components/Page.js
@@ -15,7 +15,7 @@ const GlobalStyles = createGlobalStyle`
     --grey: #3A3A3A;
     --gray: var(--grey);
     --lightGrey: #e1e1e1;
-    --lightGray: var(---lightGray);
+    --lightGray: var(---lightGrey);
     --offWhite: #ededed;
     --maxWidth: 1000px;
     --bs: 0 12px 24px 0 rgba(0,0,0,0.09);


### PR DESCRIPTION
This PR changes the var(--lightGray) to refer to the --lightGrey in Page.js global style.