### PR TITLE
Fix addToCart.ts

### DIFF
--- a/finished-application/backend/mutations/addToCart.ts
+++ b/finished-application/backend/mutations/addToCart.ts
@@ -19,7 +19,7 @@ async function addToCart(
   // 2. Query the current users cart
   const allCartItems = await context.lists.CartItem.findMany({
     where: { user: { id: sesh.itemId }, product: { id: productId } },
-    resolveField: 'id,quanity'
+    resolveFields: 'id,quantity'
   });
 
   const [existingCartItem] = allCartItems;

--- a/stepped-solutions/47/mutations/addToCart.ts
+++ b/stepped-solutions/47/mutations/addToCart.ts
@@ -19,7 +19,7 @@ async function addToCart(
   // 2. Query the current users cart
   const allCartItems = await context.lists.CartItem.findMany({
     where: { user: { id: sesh.itemId }, product: { id: productId } },
-    resolveField: 'id,quanity'
+    resolveFields: 'id,quantity'
   });
 
   const [existingCartItem] = allCartItems;


### PR DESCRIPTION
I encountered an issue where the API Explorer returned nested errors `AccessDeniedError` and `Unable to connect a CartItem.product<Product>`. There were a couple typos in the file which, after fixing, allowed my queries to go through. You actually spoke the plural `resolveFields` in the video (video 46) but typed the singular.