### PR TITLE
Fix another spelling error

### DIFF
--- a/finished-application/frontend/config.js
+++ b/finished-application/frontend/config.js
@@ -1,4 +1,4 @@
 // This is client side config only - don't put anything in here that shouldn't be public!
 export const endpoint = `http://localhost:3000/api/graphql`;
-export const prodEndpoint = `fill me is when we deploy`;
+export const prodEndpoint = `fill me in when we deploy`;
 export const perPage = 2;


### PR DESCRIPTION
export const prodEndpoint = `fill me is when we deploy`;

Should be:

export const prodEndpoint = `fill me in when we deploy`;