### PR TITLE
update apollo client to v3.3.8

### DIFF
--- a/finished-application/frontend/package-lock.json
+++ b/finished-application/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@apollo/client": "^3.3.6",
+        "@apollo/client": "^3.3.8",
         "@stripe/react-stripe-js": "^1.1.2",
         "waait": "^1.0.5",
         "next": "^10.0.5",
@@ -1416,11 +1416,12 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.13.2.tgz",
-      "integrity": "sha512-kJkpDUEs/Rp8HsAYYlDzyvQHlT6YZa95P+2GGNR8p/VvsIkt6NilAk7oeTvMRKCq7BeclB7+bmdIexog2859GQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.14.0.tgz",
+      "integrity": "sha512-ygbNt8n4DOCVpkwiLF+IrKKeNHOjtr9aXLWGP9HNJGoblSGsnVbJLstcH6/nE9Xy5ZQtlkSioFQNnthmENW6FQ==",
       "dependencies": {
-        "@wry/context": "^0.5.2"
+        "@wry/context": "^0.5.2",
+        "@wry/trie": "^0.2.1"
       }
     },
     "node_modules/node-libs-browser/node_modules/buffer": {
@@ -4880,9 +4881,10 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.6.tgz",
-      "integrity": "sha512-XSm/STyNS8aHdDigLLACKNMHwI0qaQmEHWHtTP+jHe/E1wZRnn66VZMMgwKLy2V4uHISHfmiZ4KpUKDPeJAKqg==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.8.tgz",
+      "integrity": "sha512-nYKoTfz2ivwzVee+uVHUSWS+xK166m4ycgxM7INq1kR1PD8o3WjBLmCmlajnqSx6KSZCFaTnH75PsfHvtUi1iA==",
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.0.0",
         "@types/zen-observable": "^0.8.0",
@@ -4891,7 +4893,7 @@
         "fast-json-stable-stringify": "^2.0.0",
         "graphql-tag": "^2.11.0",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.13.1",
+        "optimism": "^0.14.0",
         "prop-types": "^15.7.2",
         "symbol-observable": "^2.0.0",
         "ts-invariant": "^0.6.0",
@@ -8898,11 +8900,11 @@
       }
     },
     "node_modules/@wry/context": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.2.tgz",
-      "integrity": "sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.3.tgz",
+      "integrity": "sha512-n0uKHiWpf2ArHhmcHcUsKA+Dj0gtye/h56VmsDcoMRuK/ZPFeHKi8ck5L/ftqtF12ZbQR9l8xMPV7y+xybaRDA==",
       "dependencies": {
-        "tslib": "^1.9.3"
+        "tslib": "^1.14.1"
       }
     },
     "node_modules/@babel/traverse": {
@@ -12403,6 +12405,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/@wry/trie": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.2.1.tgz",
+      "integrity": "sha512-sYkuXZqArky2MLQCv4tLW6hX3N8AfTZ5ZMBc8jC6Yy35WYr82UYLLtjS7k/uRGHOA0yTSjuNadG6QQ6a5CS5hQ==",
+      "dependencies": {
+        "tslib": "^1.14.1"
+      }
+    },
     "node_modules/sane/node_modules/cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -15775,9 +15785,9 @@
       }
     },
     "@apollo/client": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.6.tgz",
-      "integrity": "sha512-XSm/STyNS8aHdDigLLACKNMHwI0qaQmEHWHtTP+jHe/E1wZRnn66VZMMgwKLy2V4uHISHfmiZ4KpUKDPeJAKqg==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.8.tgz",
+      "integrity": "sha512-nYKoTfz2ivwzVee+uVHUSWS+xK166m4ycgxM7INq1kR1PD8o3WjBLmCmlajnqSx6KSZCFaTnH75PsfHvtUi1iA==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.0.0",
         "@types/zen-observable": "^0.8.0",
@@ -15786,7 +15796,7 @@
         "fast-json-stable-stringify": "^2.0.0",
         "graphql-tag": "^2.11.0",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.13.1",
+        "optimism": "^0.14.0",
         "prop-types": "^15.7.2",
         "symbol-observable": "^2.0.0",
         "ts-invariant": "^0.6.0",
@@ -17983,17 +17993,25 @@
       }
     },
     "@wry/context": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.2.tgz",
-      "integrity": "sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.3.tgz",
+      "integrity": "sha512-n0uKHiWpf2ArHhmcHcUsKA+Dj0gtye/h56VmsDcoMRuK/ZPFeHKi8ck5L/ftqtF12ZbQR9l8xMPV7y+xybaRDA==",
       "requires": {
-        "tslib": "^1.9.3"
+        "tslib": "^1.14.1"
       }
     },
     "@wry/equality": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.1.tgz",
       "integrity": "sha512-8/Ftr3jUZ4EXhACfSwPIfNsE8V6WKesdjp+Dxi78Bej6qlasAxiz0/F8j0miACRj9CL4vC5Y5FsfwwEYAuhWbg==",
+      "requires": {
+        "tslib": "^1.14.1"
+      }
+    },
+    "@wry/trie": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.2.1.tgz",
+      "integrity": "sha512-sYkuXZqArky2MLQCv4tLW6hX3N8AfTZ5ZMBc8jC6Yy35WYr82UYLLtjS7k/uRGHOA0yTSjuNadG6QQ6a5CS5hQ==",
       "requires": {
         "tslib": "^1.14.1"
       }
@@ -24951,11 +24969,12 @@
       }
     },
     "optimism": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.13.2.tgz",
-      "integrity": "sha512-kJkpDUEs/Rp8HsAYYlDzyvQHlT6YZa95P+2GGNR8p/VvsIkt6NilAk7oeTvMRKCq7BeclB7+bmdIexog2859GQ==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.14.0.tgz",
+      "integrity": "sha512-ygbNt8n4DOCVpkwiLF+IrKKeNHOjtr9aXLWGP9HNJGoblSGsnVbJLstcH6/nE9Xy5ZQtlkSioFQNnthmENW6FQ==",
       "requires": {
-        "@wry/context": "^0.5.2"
+        "@wry/context": "^0.5.2",
+        "@wry/trie": "^0.2.1"
       }
     },
     "optionator": {

--- a/finished-application/frontend/package.json
+++ b/finished-application/frontend/package.json
@@ -22,7 +22,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@apollo/client": "^3.3.6",
+    "@apollo/client": "^3.3.8",
     "@apollo/link-error": "^2.0.0-beta.3",
     "@apollo/react-ssr": "^4.0.0",
     "@stripe/react-stripe-js": "^1.1.2",

--- a/sick-fits/frontend/package-lock.json
+++ b/sick-fits/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
-        "@apollo/client": "^3.2.9",
+        "@apollo/client": "^3.3.8",
         "@apollo/link-error": "^2.0.0-beta.3",
         "@apollo/react-ssr": "^4.0.0",
         "@stripe/react-stripe-js": "^1.1.2",
@@ -238,42 +238,37 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.9.tgz",
-      "integrity": "sha512-AUvYITKhJNfRNU/Cf8t/N628ADdVah1+l9Qtjd09IwScRfDGvbBTkHMAgcb6hl7vuBVqGwQRq6fPKzHgWRlisg==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.8.tgz",
+      "integrity": "sha512-nYKoTfz2ivwzVee+uVHUSWS+xK166m4ycgxM7INq1kR1PD8o3WjBLmCmlajnqSx6KSZCFaTnH75PsfHvtUi1iA==",
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.0.0",
         "@types/zen-observable": "^0.8.0",
         "@wry/context": "^0.5.2",
-        "@wry/equality": "^0.2.0",
+        "@wry/equality": "^0.3.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graphql-tag": "^2.11.0",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.13.0",
+        "optimism": "^0.14.0",
         "prop-types": "^15.7.2",
         "symbol-observable": "^2.0.0",
-        "ts-invariant": "^0.5.0",
+        "ts-invariant": "^0.6.0",
         "tslib": "^1.10.0",
         "zen-observable": "^0.8.14"
-      }
-    },
-    "node_modules/@apollo/client/node_modules/optimism": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.13.1.tgz",
-      "integrity": "sha512-16RRVYZe8ODcUqpabpY7Gb91vCAbdhn8FHjlUb2Hqnjjow1j8Z1dlppds+yAsLbreNTVylLC+tNX6DuC2vt3Kw==",
-      "dependencies": {
-        "@wry/context": "^0.5.2"
-      }
-    },
-    "node_modules/@apollo/client/node_modules/ts-invariant": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.5.1.tgz",
-      "integrity": "sha512-k3UpDNrBZpqJFnAAkAHNmSHtNuCxcU6xLiziPgalHRKZHme6T6jnKC8CcXDmk1zbHLQM8pc+rNC1Q6FvXMAl+g==",
-      "dependencies": {
-        "tslib": "^1.9.3"
       },
-      "engines": {
-        "node": ">=8"
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "subscriptions-transport-ws": "^0.9.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
       }
     },
     "node_modules/@apollo/link-error": {
@@ -293,27 +288,6 @@
         "@apollo/client": "^3.2.1"
       }
     },
-    "node_modules/@apollo/react-ssr/node_modules/@apollo/client": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.1.tgz",
-      "integrity": "sha512-w1EdCf3lvSwsxG2zbn8Rm31nPh9gQrB7u61BnU1QCM5BNIfOxiuuldzGNMHi5kI9KleisFvZl/9OA7pEkVg/yw==",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.0.0",
-        "@types/zen-observable": "^0.8.0",
-        "@wry/context": "^0.5.2",
-        "@wry/equality": "^0.2.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graphql-tag": "^2.11.0",
-        "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.12.1",
-        "prop-types": "^15.7.2",
-        "symbol-observable": "^2.0.0",
-        "terser": "^5.2.0",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.14"
-      }
-    },
     "node_modules/@apollo/react-testing": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/react-testing/-/react-testing-4.0.0.tgz",
@@ -321,28 +295,6 @@
       "dev": true,
       "dependencies": {
         "@apollo/client": "^3.2.1"
-      }
-    },
-    "node_modules/@apollo/react-testing/node_modules/@apollo/client": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.1.tgz",
-      "integrity": "sha512-w1EdCf3lvSwsxG2zbn8Rm31nPh9gQrB7u61BnU1QCM5BNIfOxiuuldzGNMHi5kI9KleisFvZl/9OA7pEkVg/yw==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.0.0",
-        "@types/zen-observable": "^0.8.0",
-        "@wry/context": "^0.5.2",
-        "@wry/equality": "^0.2.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graphql-tag": "^2.11.0",
-        "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.12.1",
-        "prop-types": "^15.7.2",
-        "symbol-observable": "^2.0.0",
-        "terser": "^5.2.0",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.14"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2699,6 +2651,11 @@
         "@types/jest": "*"
       }
     },
+    "node_modules/@types/ungap__global-this": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz",
+      "integrity": "sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g=="
+    },
     "node_modules/@types/yargs": {
       "version": "15.0.10",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.10.tgz",
@@ -2718,6 +2675,11 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.1.tgz",
       "integrity": "sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ=="
+    },
+    "node_modules/@ungap/global-this": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.4.tgz",
+      "integrity": "sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -2885,11 +2847,19 @@
       }
     },
     "node_modules/@wry/equality": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
-      "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.1.tgz",
+      "integrity": "sha512-8/Ftr3jUZ4EXhACfSwPIfNsE8V6WKesdjp+Dxi78Bej6qlasAxiz0/F8j0miACRj9CL4vC5Y5FsfwwEYAuhWbg==",
       "dependencies": {
-        "tslib": "^1.9.3"
+        "tslib": "^1.14.1"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.2.1.tgz",
+      "integrity": "sha512-sYkuXZqArky2MLQCv4tLW6hX3N8AfTZ5ZMBc8jC6Yy35WYr82UYLLtjS7k/uRGHOA0yTSjuNadG6QQ6a5CS5hQ==",
+      "dependencies": {
+        "tslib": "^1.14.1"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -11483,11 +11453,12 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.12.2.tgz",
-      "integrity": "sha512-k7hFhlmfLl6HNThIuuvYMQodC1c+q6Uc6V9cLVsMWyW514QuaxVJH/khPu2vLRIoDTpFdJ5sojlARhg1rzyGbg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.14.0.tgz",
+      "integrity": "sha512-ygbNt8n4DOCVpkwiLF+IrKKeNHOjtr9aXLWGP9HNJGoblSGsnVbJLstcH6/nE9Xy5ZQtlkSioFQNnthmENW6FQ==",
       "dependencies": {
-        "@wry/context": "^0.5.2"
+        "@wry/context": "^0.5.2",
+        "@wry/trie": "^0.2.1"
       }
     },
     "node_modules/optionator": {
@@ -14301,22 +14272,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/terser": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.3.tgz",
-      "integrity": "sha512-vRQDIlD+2Pg8YMwVK9kMM3yGylG95EIwzBai1Bw7Ot4OBfn3VP1TZn3EWx4ep2jERN/AmnVaTiGuelZSN7ds/A==",
-      "dependencies": {
-        "commander": "^2.20.0",
-        "source-map": "~0.7.2",
-        "source-map-support": "~0.5.19"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/terser-webpack-plugin": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
@@ -14626,11 +14581,16 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "node_modules/ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.6.0.tgz",
+      "integrity": "sha512-caoafsfgb8QxdrKzFfjKt627m4i8KTtfAiji0DYJfWI4A/S9ORNNpzYuD9br64kyKFgxn9UNaLLbSupam84mCA==",
       "dependencies": {
+        "@types/ungap__global-this": "^0.3.1",
+        "@ungap/global-this": "^0.4.2",
         "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ts-pnp": {
@@ -14675,9 +14635,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
@@ -15874,41 +15834,23 @@
       }
     },
     "@apollo/client": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.9.tgz",
-      "integrity": "sha512-AUvYITKhJNfRNU/Cf8t/N628ADdVah1+l9Qtjd09IwScRfDGvbBTkHMAgcb6hl7vuBVqGwQRq6fPKzHgWRlisg==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.8.tgz",
+      "integrity": "sha512-nYKoTfz2ivwzVee+uVHUSWS+xK166m4ycgxM7INq1kR1PD8o3WjBLmCmlajnqSx6KSZCFaTnH75PsfHvtUi1iA==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.0.0",
         "@types/zen-observable": "^0.8.0",
         "@wry/context": "^0.5.2",
-        "@wry/equality": "^0.2.0",
+        "@wry/equality": "^0.3.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graphql-tag": "^2.11.0",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.13.0",
+        "optimism": "^0.14.0",
         "prop-types": "^15.7.2",
         "symbol-observable": "^2.0.0",
-        "ts-invariant": "^0.5.0",
+        "ts-invariant": "^0.6.0",
         "tslib": "^1.10.0",
         "zen-observable": "^0.8.14"
-      },
-      "dependencies": {
-        "optimism": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.13.1.tgz",
-          "integrity": "sha512-16RRVYZe8ODcUqpabpY7Gb91vCAbdhn8FHjlUb2Hqnjjow1j8Z1dlppds+yAsLbreNTVylLC+tNX6DuC2vt3Kw==",
-          "requires": {
-            "@wry/context": "^0.5.2"
-          }
-        },
-        "ts-invariant": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.5.1.tgz",
-          "integrity": "sha512-k3UpDNrBZpqJFnAAkAHNmSHtNuCxcU6xLiziPgalHRKZHme6T6jnKC8CcXDmk1zbHLQM8pc+rNC1Q6FvXMAl+g==",
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "@apollo/link-error": {
@@ -15926,29 +15868,6 @@
       "integrity": "sha512-IW+x5M6eTTMbKwCfgox+BwfnZVhKTNiAjAHVdeOIc5jHIuG4oyB/gWcEonHRK6RKb+zLV1rOqpdwnJc6wchxLA==",
       "requires": {
         "@apollo/client": "^3.2.1"
-      },
-      "dependencies": {
-        "@apollo/client": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.1.tgz",
-          "integrity": "sha512-w1EdCf3lvSwsxG2zbn8Rm31nPh9gQrB7u61BnU1QCM5BNIfOxiuuldzGNMHi5kI9KleisFvZl/9OA7pEkVg/yw==",
-          "requires": {
-            "@graphql-typed-document-node/core": "^3.0.0",
-            "@types/zen-observable": "^0.8.0",
-            "@wry/context": "^0.5.2",
-            "@wry/equality": "^0.2.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "graphql-tag": "^2.11.0",
-            "hoist-non-react-statics": "^3.3.2",
-            "optimism": "^0.12.1",
-            "prop-types": "^15.7.2",
-            "symbol-observable": "^2.0.0",
-            "terser": "^5.2.0",
-            "ts-invariant": "^0.4.4",
-            "tslib": "^1.10.0",
-            "zen-observable": "^0.8.14"
-          }
-        }
       }
     },
     "@apollo/react-testing": {
@@ -15958,30 +15877,6 @@
       "dev": true,
       "requires": {
         "@apollo/client": "^3.2.1"
-      },
-      "dependencies": {
-        "@apollo/client": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.1.tgz",
-          "integrity": "sha512-w1EdCf3lvSwsxG2zbn8Rm31nPh9gQrB7u61BnU1QCM5BNIfOxiuuldzGNMHi5kI9KleisFvZl/9OA7pEkVg/yw==",
-          "dev": true,
-          "requires": {
-            "@graphql-typed-document-node/core": "^3.0.0",
-            "@types/zen-observable": "^0.8.0",
-            "@wry/context": "^0.5.2",
-            "@wry/equality": "^0.2.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "graphql-tag": "^2.11.0",
-            "hoist-non-react-statics": "^3.3.2",
-            "optimism": "^0.12.1",
-            "prop-types": "^15.7.2",
-            "symbol-observable": "^2.0.0",
-            "terser": "^5.2.0",
-            "ts-invariant": "^0.4.4",
-            "tslib": "^1.10.0",
-            "zen-observable": "^0.8.14"
-          }
-        }
       }
     },
     "@babel/code-frame": {
@@ -18134,6 +18029,11 @@
         "@types/jest": "*"
       }
     },
+    "@types/ungap__global-this": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz",
+      "integrity": "sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g=="
+    },
     "@types/yargs": {
       "version": "15.0.10",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.10.tgz",
@@ -18153,6 +18053,11 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.1.tgz",
       "integrity": "sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ=="
+    },
+    "@ungap/global-this": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.4.tgz",
+      "integrity": "sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -18320,11 +18225,19 @@
       }
     },
     "@wry/equality": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
-      "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.1.tgz",
+      "integrity": "sha512-8/Ftr3jUZ4EXhACfSwPIfNsE8V6WKesdjp+Dxi78Bej6qlasAxiz0/F8j0miACRj9CL4vC5Y5FsfwwEYAuhWbg==",
       "requires": {
-        "tslib": "^1.9.3"
+        "tslib": "^1.14.1"
+      }
+    },
+    "@wry/trie": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.2.1.tgz",
+      "integrity": "sha512-sYkuXZqArky2MLQCv4tLW6hX3N8AfTZ5ZMBc8jC6Yy35WYr82UYLLtjS7k/uRGHOA0yTSjuNadG6QQ6a5CS5hQ==",
+      "requires": {
+        "tslib": "^1.14.1"
       }
     },
     "@xtuc/ieee754": {
@@ -25442,11 +25355,12 @@
       }
     },
     "optimism": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.12.2.tgz",
-      "integrity": "sha512-k7hFhlmfLl6HNThIuuvYMQodC1c+q6Uc6V9cLVsMWyW514QuaxVJH/khPu2vLRIoDTpFdJ5sojlARhg1rzyGbg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.14.0.tgz",
+      "integrity": "sha512-ygbNt8n4DOCVpkwiLF+IrKKeNHOjtr9aXLWGP9HNJGoblSGsnVbJLstcH6/nE9Xy5ZQtlkSioFQNnthmENW6FQ==",
       "requires": {
-        "@wry/context": "^0.5.2"
+        "@wry/context": "^0.5.2",
+        "@wry/trie": "^0.2.1"
       }
     },
     "optionator": {
@@ -27811,16 +27725,6 @@
         "supports-hyperlinks": "^2.0.0"
       }
     },
-    "terser": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.3.tgz",
-      "integrity": "sha512-vRQDIlD+2Pg8YMwVK9kMM3yGylG95EIwzBai1Bw7Ot4OBfn3VP1TZn3EWx4ep2jERN/AmnVaTiGuelZSN7ds/A==",
-      "requires": {
-        "commander": "^2.20.0",
-        "source-map": "~0.7.2",
-        "source-map-support": "~0.5.19"
-      }
-    },
     "terser-webpack-plugin": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
@@ -28073,10 +27977,12 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.6.0.tgz",
+      "integrity": "sha512-caoafsfgb8QxdrKzFfjKt627m4i8KTtfAiji0DYJfWI4A/S9ORNNpzYuD9br64kyKFgxn9UNaLLbSupam84mCA==",
       "requires": {
+        "@types/ungap__global-this": "^0.3.1",
+        "@ungap/global-this": "^0.4.2",
         "tslib": "^1.9.3"
       }
     },
@@ -28115,9 +28021,9 @@
       }
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/sick-fits/frontend/package.json
+++ b/sick-fits/frontend/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@apollo/client": "^3.2.9",
+    "@apollo/client": "^3.3.8",
     "@apollo/link-error": "^2.0.0-beta.3",
     "@apollo/react-ssr": "^4.0.0",
     "@stripe/react-stripe-js": "^1.1.2",


### PR DESCRIPTION
Hey Wes,

People have been getting a `Can't find field '_allProductsMeta' on ROOT_QUERY object` error message when they query the Products - when they update the Apollo Client package the error goes away.

I updated both the `sick-fits` and `finished-application` to the latest version of Apollo Client 🙂 