### PR TITLE
Pass resolveFields: false in list API calls 

### DIFF
--- a/finished-application/backend/mutations/addToCart.ts
+++ b/finished-application/backend/mutations/addToCart.ts
@@ -33,6 +33,7 @@ async function addToCart(
     return await context.lists.CartItem.updateOne({
       id: existingCartItem.id,
       data: { quantity: existingCartItem.quantity + 1 },
+      resolveFields: false,
     });
   }
   // 4. if it isnt, create a new cart item!
@@ -40,7 +41,8 @@ async function addToCart(
     data: {
       product: { connect: { id: productId }},
       user: { connect: { id: sesh.itemId }},
-    }
+    },
+    resolveFields: false,
   })
 }
 

--- a/finished-application/backend/mutations/checkout.ts
+++ b/finished-application/backend/mutations/checkout.ts
@@ -89,7 +89,8 @@ async function checkout(
       charge: charge.id,
       items: { create: orderItems },
       user: { connect: { id: userId }}
-    }
+    },
+    resolveFields: false,
   });
   // 6. Clean up any old cart item
   const cartItemIds = user.cart.map(cartItem => cartItem.id);

--- a/stepped-solutions/47/mutations/addToCart.ts
+++ b/stepped-solutions/47/mutations/addToCart.ts
@@ -33,6 +33,7 @@ async function addToCart(
     return await context.lists.CartItem.updateOne({
       id: existingCartItem.id,
       data: { quantity: existingCartItem.quantity + 1 },
+      resolveFields: false,
     });
   }
   // 4. if it isnt, create a new cart item!
@@ -40,7 +41,8 @@ async function addToCart(
     data: {
       product: { connect: { id: productId }},
       user: { connect: { id: sesh.itemId }},
-    }
+    },
+    resolveFields: false,
   })
 }
 

--- a/stepped-solutions/58/checkout.ts
+++ b/stepped-solutions/58/checkout.ts
@@ -88,7 +88,8 @@ async function checkout(
       charge: charge.id,
       items: { create: orderItems },
       user: { connect: { id: userId }}
-    }
+    },
+    resolveFields: false,
   });
   // 6. Clean up any old cart item
   const cartItemIds = cartItems.map(cartItem => cartItem.id);

--- a/stepped-solutions/59/checkout.ts
+++ b/stepped-solutions/59/checkout.ts
@@ -88,7 +88,8 @@ async function checkout(
       charge: charge.id,
       items: { create: orderItems },
       user: { connect: { id: userId }}
-    }
+    },
+    resolveFields: false,
   });
   // 6. Clean up any old cart item
   const cartItemIds = user.cart.map(cartItem => cartItem.id);


### PR DESCRIPTION
We need to return unresolved values from our resolvers. By default `resolveFields` will be `"id"` so that we can use the resolved value on the server. If we want to return an object from our resolver as an `Order` or `CartItem`, we want to return the raw, unresolved value, so that field resolution can be handled by the calling mutation itself.

e.g. the mutation:

```
const CREATE_ORDER_MUTATION = gql`
  mutation CREATE_ORDER_MUTATION($token: String!) {
    checkout(token: $token) {
      id
      charge
      total
      items {
        id
        name
      }
    }
  }
`;```
 
would only successfully resolve the `id` field without this change. Using `resolveFields: false` in our custom queries ensures that all fields on this query are able to resolve correctly.