### PR TITLE
Update NavStyles.js

### DIFF
--- a/sick-fits/frontend/components/styles/NavStyles.js
+++ b/sick-fits/frontend/components/styles/NavStyles.js
@@ -48,6 +48,7 @@ const NavStyles = styled.ul`
     &:hover,
     &:focus {
       outline: none;
+      text-decoration:none;
       &:after {
         width: calc(100% - 60px);
       }


### PR DESCRIPTION
Remove underline from nav hover (conflicts with inline CSS added in `Header.js` in the vid #7)