### PR TITLE
Removing useEffect - Not Referenced Until Later

### DIFF
--- a/stepped-solutions/23/useForm.js
+++ b/stepped-solutions/23/useForm.js
@@ -5,11 +5,6 @@ export default function useForm(initial = {}) {
   const [inputs, setInputs] = useState(initial);
   const initialValues = Object.values(initial).join('');
 
-  useEffect(() => {
-    // This function runs when the things we are watching change
-    setInputs(initial);
-  }, [initialValues]);
-
   // {
   //   name: 'wes',
   //   description: 'nice shoes',


### PR DESCRIPTION
The useEffect in this file isn't actually covered until video 29 in the course. Might be better to remove it from here for now and then have it be updated in the future version of the file to avoid confusion.