### PR TITLE
Fix: remove extra dashes from styles variables

### DIFF
--- a/stepped-solutions/08/Page.js
+++ b/stepped-solutions/08/Page.js
@@ -15,7 +15,7 @@ const GlobalStyles = createGlobalStyle`
     --grey: #3A3A3A;
     --gray: var(--grey);
     --lightGrey: #e1e1e1;
-    --lightGray: var(---lightGrey);
+    --lightGray: var(--lightGrey);
     --offWhite: #ededed;
     --maxWidth: 1000px;
     --bs: 0 12px 24px 0 rgba(0,0,0,0.09);
@@ -33,7 +33,7 @@ const GlobalStyles = createGlobalStyle`
   }
   a {
     text-decoration: none;
-    color: var(---black);
+    color: var(--black);
   }
   a:hover {
     text-decoration: underline;


### PR DESCRIPTION
There are two lines with `---` instead of `--` which makes color variables doesn't work.