### PR TITLE
minor: removes `prettier.disableLanguages` from settings

### DIFF
--- a/sick-fits/backend/.vscode/settings.json
+++ b/sick-fits/backend/.vscode/settings.json
@@ -15,6 +15,5 @@
   "eslint.alwaysShowStatus": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": true
-  },
-  "prettier.disableLanguages": ["javascript", "javascriptreact"]
+  }
 }

--- a/sick-fits/frontend/.vscode/settings.json
+++ b/sick-fits/frontend/.vscode/settings.json
@@ -15,6 +15,5 @@
   "eslint.alwaysShowStatus": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": true
-  },
-  "prettier.disableLanguages": ["javascript", "javascriptreact"]
+  }
 }


### PR DESCRIPTION
In the .vscode folders' settings.json in both front and backend, VSCode is grumpy that the "prettier.disableLanguages" setting is deprecated. This just removes the line.