### PR TITLE
Everyone canReadProducts.

### DIFF
--- a/finished-application/backend/access.ts
+++ b/finished-application/backend/access.ts
@@ -60,9 +60,6 @@ export const rules = {
     return { order: { user: { id: session.itemId } } };
   },
   canReadProducts({ session }: ListAccessArgs) {
-    if (!isSignedIn({ session })) {
-      return false;
-    }
     if (permissions.canManageProducts({ session })) {
       return true; // They can read everything!
     }

--- a/stepped-solutions/69/access.ts
+++ b/stepped-solutions/69/access.ts
@@ -60,9 +60,6 @@ export const rules = {
     return { order: { user: { id: session.itemId } } };
   },
   canReadProducts({ session }: ListAccessArgs) {
-    if (!isSignedIn({ session })) {
-      return false;
-    }
     if (permissions.canManageProducts({ session })) {
       return true; // They can read everything!
     }


### PR DESCRIPTION
In 68/69 an `isSignedIn` check was added to canReadProducts preventing users that are not logged in to the site from browsing products. This should probably be omitted.