### PR TITLE
Fix onClick functionality on downshift results.

### DIFF
--- a/finished-application/frontend/components/Search.js
+++ b/finished-application/frontend/components/Search.js
@@ -77,7 +77,7 @@ export default function Search() {
         {isOpen &&
           items.map((item, index) => (
             <DropDownItem
-              {...getItemProps({ item })}
+              {...getItemProps({ item, index })}
               key={item.id}
               highlighted={index === highlightedIndex}
             >

--- a/stepped-solutions/52/Search.js
+++ b/stepped-solutions/52/Search.js
@@ -77,7 +77,7 @@ export default function Search() {
         {isOpen &&
           items.map((item, index) => (
             <DropDownItem
-              {...getItemProps({ item })}
+              {...getItemProps({ item, index })}
               key={item.id}
               highlighted={index === highlightedIndex}
             >


### PR DESCRIPTION
In Search.js the DropDownItem results can only be accessed with a keyboard. Adding `index` to `...getItemProps` allows the results to be clicked as well.

100% credit to [Luis Felipe Bertel Mercado on the Wes Bos Slack Chat](https://wesbos.slack.com/archives/C9G96G2UB/p1613611683317400?thread_ts=1613142191.428600&cid=C9G96G2UB
) for finding this.

(Sorry for the previous PR, accidentally forced the wrong branch.)