### PR TITLE
Update styled-components VS Code extension name

### DIFF
--- a/finished-application/backend/.vscode/extensions.json
+++ b/finished-application/backend/.vscode/extensions.json
@@ -4,6 +4,6 @@
     "wesbos.theme-cobalt2",
     "formulahendry.auto-rename-tag",
     "graphql.vscode-graphql",
-    "jpoissonnier.vscode-styled-components"
+    "styled-components.vscode-styled-components"
   ]
 }

--- a/finished-application/frontend/.vscode/extensions.json
+++ b/finished-application/frontend/.vscode/extensions.json
@@ -4,6 +4,6 @@
     "wesbos.theme-cobalt2",
     "formulahendry.auto-rename-tag",
     "graphql.vscode-graphql",
-    "jpoissonnier.vscode-styled-components"
+    "styled-components.vscode-styled-components"
   ]
 }

--- a/sick-fits/backend/.vscode/extensions.json
+++ b/sick-fits/backend/.vscode/extensions.json
@@ -4,6 +4,6 @@
     "wesbos.theme-cobalt2",
     "formulahendry.auto-rename-tag",
     "graphql.vscode-graphql",
-    "jpoissonnier.vscode-styled-components"
+    "styled-components.vscode-styled-components"
   ]
 }

--- a/sick-fits/frontend/.vscode/extensions.json
+++ b/sick-fits/frontend/.vscode/extensions.json
@@ -4,6 +4,6 @@
     "wesbos.theme-cobalt2",
     "formulahendry.auto-rename-tag",
     "graphql.vscode-graphql",
-    "jpoissonnier.vscode-styled-components"
+    "styled-components.vscode-styled-components"
   ]
 }


### PR DESCRIPTION
Type: chore

The VS Code styled-components extension has moved to an official version released by Styled Components. 
> Styled Components has moved! Make sure you're downloading it from here: https://marketplace.visualstudio.com/items?itemName=styled-components.vscode-styled-components. The jpoissonnier.vscode-styled-components version will recieve no more updates.

This was causing a complaint from VS Code that the old extension didn't exist.

This PR updates the `extensions.json` files to point to the new release 👍