### PR TITLE
Update Search.js to include ssr: false field in useLazyQuery

### DIFF
--- a/finished-application/frontend/components/Search.js
+++ b/finished-application/frontend/components/Search.js
@@ -32,6 +32,7 @@ export default function Search() {
     SEARCH_PRODUCTS_QUERY,
     {
       fetchPolicy: 'no-cache',
+      ssr: false
     }
   );
   const items = data?.searchTerms || [];


### PR DESCRIPTION
I was getting infinite browser hang (chrome) due to an ssr issue with Next and Apollo useLazyQuery. This fixes it

Hi! 
Thanks for the course :).
I'm not sure why this didn't show up during the course (Possibly because I'm using newer versions of next and apollo-client).

Anyway I think that the issue was that useLazyQuery was being server side rendered but can't be executed on the server since it is triggered after ssr is finished? The page would successfully build, but the browser would never display the app. Something or other wasn't resolving properly. I added the ssr: false flag to the useLazyQuery options and that fixes it.

I'd love to hear your thoughts and hope that this is helpful. 

Have a good one from Australia.
Tim
