### PR TITLE
Replace getInitialProps w/ Vercel version

### DIFF
--- a/finished-application/frontend/pages/_document.js
+++ b/finished-application/frontend/pages/_document.js
@@ -2,13 +2,30 @@ import Document, { Html, Head, NextScript, Main } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 
 export default class MyDocument extends Document {
-  static getInitialProps({ renderPage }) {
-    const sheet = new ServerStyleSheet();
-    const page = renderPage((App) => (props) =>
-      sheet.collectStyles(<App {...props} />)
-    );
-    const styleTags = sheet.getStyleElement();
-    return { ...page, styleTags };
+  static async getInitialProps(ctx) {
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        })
+
+      const initialProps = await Document.getInitialProps(ctx)
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      }
+    } finally {
+      sheet.seal()
+    }
   }
 
   render() {


### PR DESCRIPTION
Replaced getInitialProps with Vercel NextJS Styled Components version. 
- https://github.com/vercel/next.js/blob/canary/examples/with-styled-components/pages/_document.js

Throughout the lesson, when I hard reset my browser the flicker bug was not just a flicker but permanent. Styled-Components would lost all styling on some hot reloads, or consistently when refreshing. It caused confusion and frustration, but when you mentioned we'd fix the flicker bug appearing in the video, I figured that'd solve my issue as well.

The flicker bug fix helped so the bug didn't occur as often, but it was still happening. It looked like most of the normal fixes you'd already done, so my final attempt was to copy-pasta vercel's _getInitialProps_ directly over, and that worked. 

Great lesson, really enjoying your perspective on this tech, and as a very new dad it cracked me up to hear your little 4 y/o explorer. Looking forward to the Typescript course!

npm v5.14.4
node v12.16.2