### PR TITLE
Fix Warning: Prop `className` did not match

### DIFF
--- a/sick-fits/frontend/package.json
+++ b/sick-fits/frontend/package.json
@@ -20,6 +20,7 @@
     "apollo-upload-client": "^14.1.3",
     "babel-core": "^7.0.0-bridge.0",
     "babel-plugin-styled-components": "^1.12.0",
+    "babel-preset-next": "^1.4.0",
     "date-fns": "^2.16.1",
     "downshift": "^6.0.6",
     "graphql": "16.0.1",


### PR DESCRIPTION
When using styled components a errors pops up in console. Warning: Prop `className` did not match. Server: "sc-jSMfEi iWJuIM" Client: "sc-bczRLJ gphGdJ"

Fixed by npm i babel-preset-next.